### PR TITLE
Fix: Issue #3 - Adjust padding for mobile header overlap

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -75,7 +75,7 @@
           </aside>
 
           <!-- メインコンテンツ（右側） -->
-          <main class="flex-1 p-4 md:p-8 md:h-screen md:overflow-y-auto">
+          <main class="flex-1 px-4 pb-4 pt-20 md:p-8 md:h-screen md:overflow-y-auto">
             <div class="max-w-4xl mx-auto">
               <section
                 id="top"


### PR DESCRIPTION
This PR fixes Issue #3 by adjusting the top padding of the main content area on mobile devices to prevent overlap with the sticky header.